### PR TITLE
always download the created pdf

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -297,6 +297,7 @@ class syntax_plugin_bookcreator extends DokuWiki_Syntax_Plugin {
         $form->addElement(form_makeTextField('book_title', $title, '', '', 'edit', array('size'=> 30)));
         $form->addElement(form_makeCheckboxField('book_skipforbiddenpages', '1', 'Skip Forbidden Pages','','book_skipforbiddenpages'));
         $form->addElement(form_makeListboxField('do', $values, $selected, '', '', '', array('size'=> 1)));
+        $form->addHidden('outputTarget', 'file');
         $form->addHidden('id', $ID);
         $form->addElement(form_makeButton('submit', '', $this->getLang('create')));
         $form->endFieldset();


### PR DESCRIPTION
The dw2pdf plugin can be configured to show the pdf in the Browser window instead of opening a download dialog. However this fails for the bookcreator export both in Chrome and in IE11 (it still downloads for me in FireFox and I didn't test Edge and Safari).

Hence this extra parameter instructs the dw2pdf-plugin to still provide the outputfile as download, even when configured otherwise. This relies on splitbrain/dokuwiki-plugin-dw2pdf#301