### PR TITLE
Fix erroneous regex match

### DIFF
--- a/action/pagetools.php
+++ b/action/pagetools.php
@@ -62,7 +62,7 @@ class action_plugin_bookcreator_pagetools extends DokuWiki_Action_Plugin {
                       <br>
                       <a href="' . wl($this->getConf('book_page')) . '" class="bc__manager">
                       ' . inlineSVG(__DIR__ . '/../images/notebook-edit-outline.svg') . '
-                      &nbsp;' . $this->getLang('showbook') . '(<span id="bookcreator__pages">0</span> ' . $this->getLang('pages') . ')
+                      &nbsp;' . $this->getLang('showbook') . ' (<span id="bookcreator__pages">0</span> ' . $this->getLang('pages') . ')
                       </a>
                   </div>';
 

--- a/conf/default.php
+++ b/conf/default.php
@@ -11,7 +11,7 @@ $conf['book_page']       = 'wiki:ebook';
 $conf['help_page']       = 'wiki:ebook_help'; 
 $conf['save_namespace']  = 'wiki:ebook'; 
 
-$conf['skip_ids']        = 'sidebar,user,group,playground,wiki:syntax,wiki:ebook';
+$conf['skip_ids']        = 'sidebar,user:,group:,playground,wiki:syntax,wiki:ebook';
 
 
 //Setup VIM: ex: et ts=2 enc=utf-8 :

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -17,8 +17,8 @@ $meta['save_namespace'] = array('string');
 
 $meta['skip_ids'] = array('multicheckbox',
                           '_choices' => array( 'sidebar'
-                                              ,'user'
-                                              ,'group'
+                                              ,'user:'
+                                              ,'group:'
                                               ,'playground'
                                               ,'wiki:syntax'
                                               ,'wiki:ebook'


### PR DESCRIPTION
Actually the regex matches any word that the page contains. E.g. if the current namespace is ``arubavmc:config:apgroups``, the Bookcreator isn't shown because it contains the word ``group``, which is blacklisted by default. This commit will change the RegExp to match only if the namespace starts with ``group``.